### PR TITLE
Update reqwest dependency to 0.11 from 0.9; bump crate version to 0.2.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Segment analytics client for Rust https://segment.com/docs/librar
 edition = "2018"
 license = "MIT"
 name = "analytics"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 
 [[bin]]
@@ -14,7 +14,6 @@ required-features = ["cli"]
 
 [dependencies]
 failure = "0.1.5"
-reqwest = "0.9"
 serde_json = "1.0.39"
 
 [dependencies.chrono]
@@ -24,6 +23,10 @@ version = "0.4.6"
 [dependencies.clap]
 optional = true
 version = "2.33"
+
+[dependencies.reqwest]
+features = ["blocking", "json"]
+version = "0.11"
 
 [dependencies.serde]
 features = ["derive"]

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,15 +11,15 @@ use std::time::Duration;
 /// `HttpClient` implements [`Client`](../client/trait.Client.html); see the
 /// documentation for `Client` for more on how to send events to Segment.
 pub struct HttpClient {
-    client: reqwest::Client,
+    client: reqwest::blocking::Client,
     host: String,
 }
 
 impl Default for HttpClient {
     fn default() -> Self {
         HttpClient {
-            client: reqwest::Client::builder()
-                .connect_timeout(Some(Duration::new(10, 0)))
+            client: reqwest::blocking::Client::builder()
+                .connect_timeout(Duration::new(10, 0))
                 .build()
                 .unwrap(),
             host: "https://api.segment.io".to_owned(),
@@ -34,7 +34,7 @@ impl HttpClient {
     /// If you don't care to re-use an existing `reqwest::Client`, you can use
     /// the `Default::default` value, which will send events to
     /// `https://api.segment.io`.
-    pub fn new(client: reqwest::Client, host: String) -> HttpClient {
+    pub fn new(client: reqwest::blocking::Client, host: String) -> HttpClient {
         HttpClient { client, host }
     }
 }


### PR DESCRIPTION
The use of an old version of `reqwest` pulls in many otherwise unnecessary (and old) crate dependencies into our binary that uses this crate.  I updated the dependency to 0.11, making the necessary (small) changes to the code to account for `reqwest` changing their default API to an asynchronous one in their 0.10 release.

I also bumped the version number for analytics-rust to 0.2.1 such that other users can stick with the existing version should they choose to.

Tests continue to pass, and I verified that this still works in practice by building our application against this updated analytics crate (as a local dependency).